### PR TITLE
Make vcflib a submodule via https rather than ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,4 +33,4 @@
 	url = git://github.com/samtools/bcftools.git
 [submodule "dist/vcflib"]
 	path = dist/vcflib
-	url = git@github.com:vcflib/vcflib.git
+	url = https://github.com/vcflib/vcflib.git


### PR DESCRIPTION
You made vcf a submodule via ssh which will fail if you dont have a git account with a ssh key loaded. Here I switch it to access the same repo via https which doesnt require a key or even an account. Id also recommend you edit your readme to use https rather than ssh too:

 mkdir /usr/local/smrtsv
 cd /usr/local/smrtsv
-git clone --recursive git@github.com:EichlerLab/pacbio_variant_caller.git .
+git clone --recursive https://github.com/EichlerLab/pacbio_variant_caller.git .

Cheers,

Mike